### PR TITLE
Add slow tag to nosetests that take longer than 1s

### DIFF
--- a/horton/.floo
+++ b/horton/.floo
@@ -1,0 +1,3 @@
+{
+    "url": "https://floobits.com/horton-devs/horton"
+}

--- a/horton/.flooignore
+++ b/horton/.flooignore
@@ -1,0 +1,8 @@
+#*
+*.o
+*.pyc
+*~
+extern/
+node_modules/
+tmp
+vendor/

--- a/horton/correlatedwfn/test/test_1dm_ap1rog.py
+++ b/horton/correlatedwfn/test/test_1dm_ap1rog.py
@@ -26,6 +26,7 @@ import numpy as np
 from horton.test.common import check_delta
 
 
+@attr('slow')
 def test_ap1rog_one_dm():
     fn_xyz = context.get_fn('test/li2.xyz')
     mol = IOData.from_file(fn_xyz)

--- a/horton/correlatedwfn/test/test_geminals.py
+++ b/horton/correlatedwfn/test/test_geminals.py
@@ -71,6 +71,7 @@ def test_ap1rog_cs():
     assert (abs(energy - -1.143420629378) < 1e-6)
 
 
+@attr('slow')
 def test_ap1rog_cs_scf():
     lf, occ_model, one, er, external, exp_alpha, olp = prepare_hf('6-31G')
 
@@ -81,6 +82,8 @@ def test_ap1rog_cs_scf():
     assert (abs(energy - -1.151686291339) < 1e-6)
 
 
+@attr('slow')
+@attr('slow')
 def test_ap1rog_cs_scf_restart():
     lf, occ_model, one, er, external, exp_alpha, olp = prepare_hf('6-31G')
 
@@ -88,6 +91,8 @@ def test_ap1rog_cs_scf_restart():
     geminal_solver = RAp1rog(lf, occ_model)
     guess = np.array([-0.1, -0.05, -0.02])
 
+@attr('slow')
+@attr('slow')
     with tmpdir('horton.correlatedwfn.test.test_geminals.test_ap1rog_cs_scf_restart') as dn:
         checkpoint_fn = '%s/checkpoint.h5' % dn
         energy, g, l = geminal_solver(one, er, external['nn'], exp_alpha, olp,

--- a/horton/correlatedwfn/test/test_lagrange.py
+++ b/horton/correlatedwfn/test/test_lagrange.py
@@ -25,6 +25,7 @@ import numpy as np
 from nose.tools import assert_raises
 from horton import *
 
+@attr('slow')
 def test_ap1rog_lagrange():
     fn_xyz = context.get_fn('test/li2.xyz')
     mol = IOData.from_file(fn_xyz)

--- a/horton/espfit/test/test_cext.py
+++ b/horton/espfit/test/test_cext.py
@@ -26,6 +26,7 @@ from horton import *
 from horton.test.common import get_random_cell
 
 
+@attr('slow')
 def test_pair_ewald3d_invariance_rcut():
     np.random.seed(0)
     alpha_scale = 4.5

--- a/horton/espfit/test/test_cost.py
+++ b/horton/espfit/test/test_cost.py
@@ -261,6 +261,7 @@ def test_esp_cost_solve_regularized():
     assert abs(gradient[10:]).max() < 1e-10
 
 
+@attr('slow')
 def test_compare_cubetools():
     # Load structure from cube file
     fn_cube = context.get_fn('test/jbw_coarse_aedens.cube')

--- a/horton/gbasis/test/test_fns.py
+++ b/horton/gbasis/test/test_fns.py
@@ -456,13 +456,16 @@ def test_dm_kinetic_n2_sto3g():
 def test_dm_kinetic_h3_321g():
     check_dm_kinetic('test/h3_pbe_321g.fchk', 5e-5)
 
+@attr('slow')
 def test_dm_kinetic_co_ccpv5z_cart():
     check_dm_kinetic('test/co_ccpv5z_cart_hf_g03.fchk', 4e-4)
 
+@attr('slow')
 def test_dm_kinetic_co_ccpv5z_pure():
     check_dm_kinetic('test/co_ccpv5z_pure_hf_g03.fchk', 4e-4)
 
 
+@attr('slow')
 def test_kinetic_functional_deriv():
     fn_fchk = context.get_fn('test/n2_hfs_sto3g.fchk')
     mol = IOData.from_file(fn_fchk)

--- a/horton/geminals/APIG.py
+++ b/horton/geminals/APIG.py
@@ -1,0 +1,342 @@
+#!/usr/bin/env python2
+
+from __future__ import division, print_function
+import numpy as np
+from itertools import permutations
+from horton.geminals.Geminal import Geminal
+
+class GeminalAPIG(Geminal):
+    """
+    Base geminal class, serving as a template for specific AP*G implementations.
+    Contains information about the geminal wavefunction.
+
+    Attributes
+    ----------
+    flavor : str or None
+        The 'flavor' of AP*G implementation contained in the instance of the
+        object.
+    npairs : int
+        The number of electron pairs in the geminal.
+    orb : 2-index np.ndarray, dtype=np.float64
+        The orbital coefficient matrix.
+    coeffs : 2-index np.ndarray, dtype=np.float64
+        The geminal coefficient matrix.
+    proj_space : list
+        A list of SlaterDets making up the projection space {\Phi}.
+    overlap_cache : dict
+        Cached computation results for <\Phi|\Psi> and similar.
+
+    Methods
+    -------
+    clear_overlap_cache() :
+        Delete the stored Slater determinant overlaps from the memory cache.
+    optimize_coeffs(solver) :
+        Update the coeffs matrix by minimizing {<\Phi|H|\Psi> = E<\Phi|\Psi>}
+        (the projected Schrodinger equation method) according to the passed
+        solver.
+    optimize_orbs(optimizer) :
+        Optimize the orbitals of the geminal \Psi according to the passed
+        optimizer.
+    compute_permanent() :
+        Evaluate the permanent of the coeffs matrix.
+    compute_energy() :
+        Evaluate the energy of the geminal \Psi according to ham.  This can be
+        simply passed to HORTON v2 as it is now.
+    compute_overlap(phi) :
+        Evaluate the Slater determinant overlap <phi|\Psi>.  Retrieve it from memory if it
+        has previously been computed, otherwise do the computation and index
+        the result in the overlap_cache.  If the overlap to be returned will not
+        be accessed again, delete it from overlap_cache.
+    generate_nonlinear_equations(derivative=False) :
+        Compute the set of non-linear equations that can be passed to the
+        projected Schrodinger equation solver.  This requires:
+        * Computation of the ordered set of non-zero overlaps required for the
+          equations.
+        * The computation of the geminal \Psi's energy according to ham (this
+          can be passed to HORTON 2.0 as it is now).
+        * Optionally, the evaluation of the derivatives of the non-linear
+          equations with respect to both {c} and energy.
+    generate_single(phi, p, q) :
+        Return the single excitation of a Slater determinant \Phi from orbital p
+        to q.
+    generate_double(phi, p, q, r, s) :
+        Return the double excitation of a Slater determinant \Phi from orbitals
+        p and q to orbitals s and r.
+    """
+
+    def __init__(self, npairs, orb, guess, proj_space=None):
+        """
+        Parameters
+        ---------
+        npairs : int
+            The number of electron pairs in the geminal.
+        orb : 2-index np.ndarray, dtype=np.float64
+            The orbital coefficient matrix.
+        guess : 2-index np.ndarray, dtype=np.float64
+            The initial guess for the geminal coefficients.
+        proj_space : ProjectionSpace
+            A container for SlaterDets making up the projection space {\Phi} and
+            cached computation results for <\Phi|\Psi> and similar.
+
+        Raises
+        ------
+        NotImplementedError
+        """
+
+        self.flavor = None
+
+        self.npairs = npairs
+        self.orb = orb
+        self.coeffs = guess
+
+        if proj_space is None:
+            self.proj_space = []
+            for i in range(self.npairs):
+                self.proj_space.append(2**i)
+        else:
+            self.proj_space = proj_space
+
+        self.overlap_cache = {}
+
+        #raise NotImplementedError
+
+    def clear_overlap_cache(self):
+        """
+        Clears any stored Slater determinant overlaps from the overlap cache.
+        """
+
+        del self.overlap_cache
+        self.overlap_cache = {}
+
+    def optimize_coeffs(self, solver):
+        """
+        Update the coeffs matrix by minimizing {<\Phi|H|\Psi> = E<\Phi|\Psi>}
+        (the projected Schrodinger equation method) according to the passed
+        solver.
+
+        Parameters
+        ----------
+        solver : Solver
+            The callable object containing the algorithm for solving the
+            projected Schrodinger equation and converging the coefficient
+            matrix.
+        """
+
+        solver(self)
+
+    def optimize_orbs(self, optimizer):
+        """
+        Optimize the orbitals of the geminal \Psi according to the passed
+        optimizer.
+
+        Parameters
+        ----------
+        optimizer : Optimizer
+            The callable object containing the algorithm for optimizing the
+            orbitals of the geminal \Psi.
+        """
+
+        optimizer(self)
+
+    def compute_permanent(self, matrix=None):
+        """
+        Evaluate the permanent of the coeffs matrix.  The base Geminal class
+        implements the *most* naive permanent evaluator using itertools
+        permutations.
+
+        Parameters
+        ----------
+        matrix : 2-D np.ndarray, optional
+            If specified, the permanent of this matrix will be calculated
+            instead of that of self.coeffs.
+
+        Returns
+        -------
+        permanent :
+            The permanent of `self.coeffs' or `matrix'.
+        """
+
+        if matrix is None:
+            mat = self.coeffs
+        else:
+            mat = matrix
+
+        assert (mat.shape[0] == mat.shape[1])
+
+        for perm in permutations(range(mat.shape[0])):
+            j, term = 0, 1
+            for i in perm:
+                term *= test[i][j]
+                j += 1
+            permanent += term
+
+        return permanent
+
+    def compute_energy(self, ham):
+        """
+        Evaluate the energy of the geminal \Psi according to ham.  This can be
+        simply passed to HORTON v2 as it is now.
+
+        Parameters
+        ----------
+        ham : 4-index np.ndarray, dtype=np.float64
+            The Hamiltonian matrix for the geminal wavefunction.
+
+        Returns
+        -------
+        Energy : np.float64
+            The energy of the geminal \Psi according to ham.
+
+        Raises
+        ------
+        NotImplementedError
+        """
+
+        raise NotImplementedError
+
+    def compute_overlap(self, phi):
+        """
+        Evaluate the overlap <slater_det|\Psi>.  Retrieve it from memory if it
+        has previously been computed, otherwise do the computation and index
+        the result in the overlap_cache.  If the overlap to be returned will not
+        be accessed again, delete it from overlap_cache.
+
+        Parameters
+        ----------
+        phi : object
+            Some sort of unique description of the Slater determinant whose
+            overlap with \Psi we wish to compute.
+
+        Returns
+        -------
+        overlap : object
+            The result of the overlap computation for the Slater determinant phi.
+        cache_flag : bool
+            True if the result was pulled from cache, and False if it had to be
+            computed.
+        """
+
+        if phi in self.overlap_cache:
+            cache_flag = True
+            print("O Cached")
+            overlap = self.overlap_cache[phi]
+        else:
+            cache_flag = False
+            print("X Computing")
+            overlap  = "Fake Computation"
+            self.overlap_cache[phi] = overlap
+
+        return overlap, cache_flag
+
+    @staticmethod
+    def generate_single(phi, p, q):
+        """
+        Return the single excitation of a Slater determinant \Phi from orbital p
+        to orbital q.
+
+        Parameters
+        ----------
+        phi : int
+            The Slater determinant to be excited.
+        p : int
+            The index of the orbital from which the excitation occurs.
+        q : int
+            The index of the orbital to which the excitation occurs.
+
+        Returns
+        -------
+        excitation : object
+            The singly-excited Slater determinant.
+        """
+
+        pmask = ~(1 << p)
+        qmask = 1 << q
+
+        excitation = phi
+        excitation &= pmask
+        excitation |= qmask
+
+        return excitation
+
+    @staticmethod
+    def generate_double(phi, p, q, s, r):
+        """
+        Return the double excitation of a Slater determinant \Phi from orbitals
+        p and q to orbitals s and r.
+
+        Parameters
+        ----------
+        phi : int
+            The Slater determinant to be excited.
+        p : int
+            The index of the orbital from which the excitation occurs.
+        q : int
+            The index of the orbital from which the excitation occurs.
+        s : int
+            The index of the orbital to which the excitation occurs.
+        r : int
+            The index of the orbital to which the excitation occurs.
+
+        Returns
+        -------
+        excitation : object
+            The doubly-excited Slater determinant.
+
+        Raises
+        ------
+        AssertionError :
+            Indices p and q cannot be equal, and indices s and r cannot be equal.
+        """
+        assert ((p != q) and (s != r))
+
+        pmask = ~(1 << p)
+        qmask = ~(1 << q)
+        smask = 1 << s
+        rmask = 1 << r
+
+        excitation = phi
+        excitation &= pmask
+        excitation &= qmask
+        excitation |= smask
+        excitation |= rmask
+
+        return excitation
+
+    def generate_nonlinear_equations(self, ham, derivative=False):
+
+        """
+        Compute the set of non-linear equations that can be passed to the
+        projected Schrodinger equation solver.  This requires:
+        * Computation of the ordered set of non-zero overlaps required for the
+          equations.
+        * The computation of the geminal \Psi's energy according to ham (this
+          can be passed to/from HORTON 2.0 as it is now).
+        * Optionally, the evaluation of the derivatives of the non-linear
+          equations with respect to both {c} and energy.
+
+        Parameters
+        ----------
+        ham : 4-index np.ndarray, dtype=np.float64
+            The Hamiltonian matrix for the geminal wavefunction.
+
+        Returns
+        -------
+        equations : list of [functions | lambdas]
+            A list of functions or lambdas corresponding to the non-linear
+            equations to be solved.
+        deriv_wrt_c : list(s) of [functions | lambdas] (if derivative=True)
+            A list of 'equations' (as the above variable), where each
+            corresponds to the derivative of the equation w.r.t. a
+            coefficient.
+        deriv_wrt_energy : list of [functions | lambdas] (if derivative=True)
+            A list of 'equations' (as the above variable), where each
+            corresponds to the derivative of the equation w.r.t. energy.
+
+        Raises
+        ------
+        NotImplementedError
+        """
+
+        raise NotImplementedError
+
+# -*- -*-

--- a/horton/grid/test/test_poisson.py
+++ b/horton/grid/test/test_poisson.py
@@ -27,6 +27,7 @@ import numpy as np
 from horton import *
 
 
+@attr('slow')
 def test_solve_poisson_becke_n2():
     mol = IOData.from_file(context.get_fn('test/n2_hfs_sto3g.fchk'))
     lmaxmax = 4

--- a/horton/grid/test/test_uniform.py
+++ b/horton/grid/test/test_uniform.py
@@ -140,6 +140,7 @@ def test_uig_eval_spline_with_integration():
         assert abs(uig.integrate(data) - expected) < 1e-3
 
 
+@attr('slow')
 def test_uig_eval_spline_3d_random():
     cs = get_cosine_spline()
 
@@ -263,6 +264,7 @@ def test_uig_eval_spline_add_random():
         assert abs(output1 + output2 - output3).max() < 1e-10
 
 
+@attr('slow')
 def test_weight_corrections():
     from horton.part.test.common import get_fake_co
 

--- a/horton/io/test/test_cif.py
+++ b/horton/io/test/test_cif.py
@@ -188,6 +188,7 @@ def test_dump_load_consistency():
     assert abs(frac0 - frac1).max() < 1e-6
 
 
+@attr('slow')
 def test_load_cage():
     mol = IOData.from_file(context.get_fn('test/cage.cif'))
     assert (mol.coordinates != 0).all()

--- a/horton/meanfield/test/test_scf_ediis.py
+++ b/horton/meanfield/test/test_scf_ediis.py
@@ -40,18 +40,22 @@ def test_water_cs_hfs():
     check_water_cs_hfs(EDIISSCFSolver(threshold=1e-6))
 
 
+@attr('slow')
 def test_n2_cs_hfs():
     check_n2_cs_hfs(EDIISSCFSolver(threshold=1e-6))
 
 
+@attr('slow')
 def test_h3_os_hfs():
     check_h3_os_hfs(EDIISSCFSolver(threshold=1e-6))
 
 
+@attr('slow')
 def test_co_cs_pbe():
     check_co_cs_pbe(EDIISSCFSolver(threshold=1e-5))
 
 
+@attr('slow')
 def test_h3_os_pbe():
     check_h3_os_pbe(EDIISSCFSolver(threshold=1e-6))
 

--- a/horton/meanfield/test/test_scf_ediis2.py
+++ b/horton/meanfield/test/test_scf_ediis2.py
@@ -40,6 +40,7 @@ def test_water_cs_hfs():
     check_water_cs_hfs(EDIIS2SCFSolver(threshold=1e-6))
 
 
+@attr('slow')
 def test_n2_cs_hfs():
     check_n2_cs_hfs(EDIIS2SCFSolver(threshold=1e-6))
 
@@ -48,9 +49,11 @@ def test_h3_os_hfs():
     check_h3_os_hfs(EDIIS2SCFSolver(threshold=1e-6))
 
 
+@attr('slow')
 def test_co_cs_pbe():
     check_co_cs_pbe(EDIIS2SCFSolver(threshold=1e-5))
 
 
+@attr('slow')
 def test_h3_os_pbe():
     check_h3_os_pbe(EDIIS2SCFSolver(threshold=1e-6))

--- a/horton/meanfield/test/test_scf_oda.py
+++ b/horton/meanfield/test/test_scf_oda.py
@@ -41,18 +41,22 @@ def test_water_cs_hfs():
     check_water_cs_hfs(ODASCFSolver(threshold=1e-6))
 
 
+@attr('slow')
 def test_n2_cs_hfs():
     check_n2_cs_hfs(ODASCFSolver(threshold=1e-6))
 
 
+@attr('slow')
 def test_h3_os_hfs():
     check_h3_os_hfs(ODASCFSolver(threshold=1e-6))
 
 
+@attr('slow')
 def test_co_cs_pbe():
     check_co_cs_pbe(ODASCFSolver(threshold=1e-5))
 
 
+@attr('slow')
 def test_h3_os_pbe():
     check_h3_os_pbe(ODASCFSolver(threshold=1e-6))
 

--- a/horton/part/test/test_cpart.py
+++ b/horton/part/test/test_cpart.py
@@ -57,6 +57,7 @@ def check_jbw_coarse(local):
         assert abs(cpart['pseudo_populations'].sum() - ugrid.integrate(wcor, moldens)) < 1e-10
 
 
+@attr('slow')
 def test_hirshfeld_jbw_coarse_local():
     check_jbw_coarse(True)
 
@@ -96,10 +97,12 @@ def check_fake(scheme, pseudo, dowcor, local, absmean, **kwargs):
         check_proatom_splines(cpart)
 
 
+@attr('slow')
 def test_hirshfeld_fake_local():
     check_fake('h', pseudo=False, dowcor=True, local=True, absmean=0.112)
 
 
+@attr('slow')
 def test_hirshfeld_fake_global():
     check_fake('h', pseudo=False, dowcor=True, local=False, absmean=0.112)
 
@@ -121,10 +124,12 @@ def test_hirshfeld_fake_pseudo_nowcor_global():
 
 
 
+@attr('slow')
 def test_hirshfeld_i_fake_local():
     check_fake('hi', pseudo=False, dowcor=True, local=True, absmean=0.428, threshold=1e-5)
 
 
+@attr('slow')
 def test_hirshfeld_i_fake_global():
     check_fake('hi', pseudo=False, dowcor=True, local=False, absmean=0.428, threshold=1e-5)
 
@@ -145,14 +150,19 @@ def test_hirshfeld_i_fake_pseudo_nowcor_global():
     check_fake('hi', pseudo=True, dowcor=True, local=False, absmean=0.400, threshold=1e-4)
 
 
+@attr('slow')
+@attr('slow')
 def test_hirshfeld_i_fake_local_greedy():
     check_fake('hi', pseudo=False, dowcor=True, local=True, absmean=0.428, threshold=1e-5, greedy=True)
 
 
+@attr('slow')
+@attr('slow')
 def test_hirshfeld_i_fake_global_greedy():
     check_fake('hi', pseudo=False, dowcor=True, local=False, absmean=0.428, threshold=1e-5, greedy=True)
 
 
+@attr('slow')
 def test_hirshfeld_i_fake_pseudo_local_greedy():
     check_fake('hi', pseudo=True, dowcor=True, local=True, absmean=0.400, threshold=1e-4, greedy=True)
 
@@ -161,6 +171,7 @@ def test_hirshfeld_i_fake_pseudo_global_greedy():
     check_fake('hi', pseudo=True, dowcor=True, local=False, absmean=0.400, threshold=1e-4, greedy=True)
 
 
+@attr('slow')
 def test_hirshfeld_i_fake_pseudo_nowcor_local_greedy():
     check_fake('hi', pseudo=True, dowcor=True, local=True, absmean=0.400, threshold=1e-4, greedy=True)
 
@@ -171,49 +182,65 @@ def test_hirshfeld_i_fake_pseudo_nowcor_global_greedy():
 
 
 
+@attr('slow')
 def test_hirshfeld_e_fake_local():
     check_fake('he', pseudo=False, dowcor=True, local=True, absmean=0.323, threshold=1e-4)
 
 
+@attr('slow')
 def test_hirshfeld_e_fake_global():
     check_fake('he', pseudo=False, dowcor=True, local=False, absmean=0.373, threshold=1e-4)
 
 
+@attr('slow')
 def test_hirshfeld_e_fake_pseudo_local():
     check_fake('he', pseudo=True, dowcor=True, local=True, absmean=0.396, threshold=1e-4)
 
 
+@attr('slow')
 def test_hirshfeld_e_fake_pseudo_global():
     check_fake('he', pseudo=True, dowcor=True, local=False, absmean=0.396, threshold=1e-4)
 
 
+@attr('slow')
 def test_hirshfeld_e_fake_pseudo_nowcor_local():
     check_fake('he', pseudo=True, dowcor=True, local=True, absmean=0.396, threshold=1e-4)
 
 
+@attr('slow')
 def test_hirshfeld_e_fake_pseudo_nowcor_global():
     check_fake('he', pseudo=True, dowcor=True, local=False, absmean=0.396, threshold=1e-4)
 
 
+@attr('slow')
+@attr('slow')
 def test_hirshfeld_e_fake_local_greedy():
     check_fake('he', pseudo=False, dowcor=True, local=True, absmean=0.323, threshold=1e-4, greedy=True)
 
 
+@attr('slow')
+@attr('slow')
 def test_hirshfeld_e_fake_global_greedy():
     check_fake('he', pseudo=False, dowcor=True, local=False, absmean=0.374, threshold=1e-4, greedy=True)
 
 
+@attr('slow')
+@attr('slow')
 def test_hirshfeld_e_fake_pseudo_local_greedy():
     check_fake('he', pseudo=True, dowcor=True, local=True, absmean=0.396, threshold=1e-4, greedy=True)
 
 
+@attr('slow')
 def test_hirshfeld_e_fake_pseudo_global_greedy():
     check_fake('he', pseudo=True, dowcor=True, local=False, absmean=0.396, threshold=1e-4, greedy=True)
 
 
+@attr('slow')
+@attr('slow')
 def test_hirshfeld_e_fake_pseudo_nowcor_local_greedy():
     check_fake('he', pseudo=True, dowcor=True, local=True, absmean=0.396, threshold=1e-4, greedy=True)
 
 
+@attr('slow')
 def test_hirshfeld_e_fake_pseudo_nowcor_global_greedy():
     check_fake('he', pseudo=True, dowcor=True, local=False, absmean=0.396, threshold=1e-4, greedy=True)

--- a/horton/part/test/test_wpart.py
+++ b/horton/part/test/test_wpart.py
@@ -96,6 +96,7 @@ def test_hirshfeld_e_water_hf_sto3g_local():
     check_water_hf_sto3g('he', expecting, local=True)
 
 
+@attr('slow')
 def test_hirshfeld_e_water_hf_sto3g_global():
     expecting = np.array([-0.422794483125, 0.211390419810, 0.211404063315]) # From HiPart
     check_water_hf_sto3g('he', expecting, local=False)
@@ -106,6 +107,7 @@ def test_hirshfeld_e_water_hf_sto3g_local_greedy():
     check_water_hf_sto3g('he', expecting, local=True, greedy=True)
 
 
+@attr('slow')
 def test_hirshfeld_e_water_hf_sto3g_global_greedy():
     expecting = np.array([-0.422794483125, 0.211390419810, 0.211404063315]) # From HiPart
     check_water_hf_sto3g('he', expecting, local=False, greedy=True)
@@ -162,46 +164,58 @@ def test_hirshfeld_msa_hf_lan_global():
     check_msa_hf_lan('h', expecting, local=False)
 
 
+@attr('slow')
 def test_hirshfeld_i_msa_hf_lan_local():
     expecting = np.array([1.14305602, -0.52958298, -0.51787452, -0.51302759, -0.50033981, 0.21958586, 0.23189187, 0.22657354, 0.23938904])
     check_msa_hf_lan('hi', expecting, local=True)
 
 
+@attr('slow')
 def test_hirshfeld_i_msa_hf_lan_global():
     expecting = np.array([1.14305602, -0.52958298, -0.51787452, -0.51302759, -0.50033981, 0.21958586, 0.23189187, 0.22657354, 0.23938904])
     check_msa_hf_lan('hi', expecting, local=False)
 
 
+@attr('slow')
 def test_hirshfeld_i_msa_hf_lan_local_greedy():
     expecting = np.array([1.14305602, -0.52958298, -0.51787452, -0.51302759, -0.50033981, 0.21958586, 0.23189187, 0.22657354, 0.23938904])
     check_msa_hf_lan('hi', expecting, local=True, greedy=True)
 
 
+@attr('slow')
+@attr('slow')
 def test_hirshfeld_i_msa_hf_lan_global_greedy():
     expecting = np.array([1.14305602, -0.52958298, -0.51787452, -0.51302759, -0.50033981, 0.21958586, 0.23189187, 0.22657354, 0.23938904])
     check_msa_hf_lan('hi', expecting, local=False, greedy=True)
 
 
+@attr('slow')
 def test_hirshfeld_e_msa_hf_lan_local():
     expecting = np.array([1.06135407, -0.51795437, -0.50626239, -0.50136175, -0.48867641, 0.22835963, 0.240736, 0.23528162, 0.24816043])
     check_msa_hf_lan('he', expecting, local=True)
 
 
+@attr('slow')
 def test_hirshfeld_e_msa_hf_lan_global():
     expecting = np.array([1.06135407, -0.51795437, -0.50626239, -0.50136175, -0.48867641, 0.22835963, 0.240736, 0.23528162, 0.24816043])
     check_msa_hf_lan('he', expecting, local=False)
 
 
+@attr('slow')
+@attr('slow')
 def test_hirshfeld_e_msa_hf_lan_local_greedy():
     expecting = np.array([1.06135407, -0.51795437, -0.50626239, -0.50136175, -0.48867641, 0.22835963, 0.240736, 0.23528162, 0.24816043])
     check_msa_hf_lan('he', expecting, local=True, greedy=True)
 
 
+@attr('slow')
+@attr('slow')
 def test_hirshfeld_e_msa_hf_lan_global_greedy():
     expecting = np.array([1.06135407, -0.51795437, -0.50626239, -0.50136175, -0.48867641, 0.22835963, 0.240736, 0.23528162, 0.24816043])
     check_msa_hf_lan('he', expecting, local=False, greedy=True)
 
 
+@attr('slow')
 def test_is_msa_hf_lan():
     expecting = np.array([1.1721364, -0.5799622, -0.5654549, -0.5599638, -0.5444145, 0.2606699, 0.2721848, 0.2664377, 0.2783666]) # from HiPart
     check_msa_hf_lan('is', expecting, needs_padb=False)

--- a/horton/scripts/test/test_atomdb.py
+++ b/horton/scripts/test/test_atomdb.py
@@ -136,7 +136,9 @@ def make_fake_run_script(program, dn):
         print >> f, 'echo "Foo"'
 
 
+@attr('slow')
 def test_script_convert_cp2k():
+@attr('slow')
     with tmpdir('horton.scripts.test.test_atomdb.test_script_convert_cp2k') as dn:
         copy_atom_output('atom_op2.cp2k.out', 8, +2, 3, dn, 'atom.cp2k.out')
         copy_atom_output('atom_op1.cp2k.out', 8, +1, 4, dn, 'atom.cp2k.out')
@@ -156,7 +158,9 @@ def test_script_convert_cp2k():
         assert padb.get_rgrid(8).size == 71
 
 
+@attr('slow')
 def test_script_convert_g09():
+@attr('slow')
     with tmpdir('horton.scripts.test.test_atomdb.test_script_convert_g09') as dn:
         copy_atom_output('atom_014_013_hf_lan.fchk', 14, +1, 2, dn, 'atom.fchk')
         make_fake_run_script('g09', dn)
@@ -171,7 +175,9 @@ def test_script_convert_g09():
         assert padb.get_rgrid(14).size == 49
 
 
+@attr('slow')
 def test_script_convert_g03():
+@attr('slow')
     with tmpdir('horton.scripts.test.test_atomdb.test_script_convert_g03') as dn:
         copy_atom_output('atom_001_001_hf_sto3g.fchk', 1,  0, 2, dn, 'atom.fchk')
         copy_atom_output('atom_001_002_hf_sto3g.fchk', 1, -1, 1, dn, 'atom.fchk')

--- a/horton/scripts/test/test_cpart.py
+++ b/horton/scripts/test/test_cpart.py
@@ -57,12 +57,14 @@ def check_script_jbw_coarse(scheme):
             assert scheme + '_r1' in f['cpart']
 
 
+@attr('slow')
 def test_script_jbw_coarse_h():
     # other schemes don't work because the cube file is too crappy.
     check_script_jbw_coarse('h')
 
 
 def check_script_lta(fn_sym, suffix, do_spin=False):
+@attr('slow')
     with tmpdir('horton.scripts.test.test_cpart.test_script_lta_coarse_h_%s' % suffix) as dn:
         # prepare files
         if fn_sym is not None:
@@ -106,17 +108,25 @@ def check_script_lta(fn_sym, suffix, do_spin=False):
                     assert ds.shape[1] == 2
 
 
+@attr('slow')
 def test_script_lta():
     check_script_lta(None, 'nosym')
 
 
+@attr('slow')
+@attr('slow')
 def test_script_lta_spin():
     check_script_lta(None, 'nosym_spin', True)
 
 
+@attr('slow')
+@attr('slow')
 def test_script_lta_sym():
     check_script_lta('lta_gulp.cif', 'sym')
 
 
+@attr('slow')
+@attr('slow')
+@attr('slow')
 def test_script_lta_sym_spin():
     check_script_lta('lta_gulp.cif', 'sym_spin', True)

--- a/horton/scripts/test/test_espfit.py
+++ b/horton/scripts/test/test_espfit.py
@@ -45,6 +45,7 @@ def test_wfar():
     assert parse_wfar('4.2:0.3') == (4.2*angstrom, 0.3*angstrom)
 
 
+@attr('slow')
 def test_scripts():
     # Generate some random system with random esp data
     natom = 5
@@ -62,6 +63,7 @@ def test_scripts():
     mol_rho.cube_data = rho_cube_data
 
     # Write the cube file to the tmpdir and run scripts (run 1)
+@attr('slow')
     with tmpdir('horton.scripts.test.test_espfit.test_scripts') as dn:
         mol_esp.to_file(os.path.join(dn, 'esp.cube'))
         check_script('horton-esp-cost.py esp.cube esp.h5 --wnear=0:1.0:0.5', dn)
@@ -71,6 +73,7 @@ def test_scripts():
         check_files(dn, ['esp.h5', 'other.h5', 'foo.h5', 'gen.h5'])
 
     # Write the cube file to the tmpdir and run scripts (run 2)
+@attr('slow')
     with tmpdir('horton.scripts.test.test_espfit.test_scripts2') as dn:
         mol_esp.to_file(os.path.join(dn, 'esp.cube'))
         mol_rho.to_file(os.path.join(dn, 'rho.cube'))
@@ -82,8 +85,10 @@ def test_scripts():
         check_files(dn, ['esp.h5', 'other.h5', 'foo.h5', 'gen.h5'])
 
 
+@attr('slow')
 def test_scripts_symmetry():
     # Write the cube file to the tmpdir and run scripts
+@attr('slow')
     with tmpdir('horton.scripts.test.test_espfit.test_scripts_symmetry') as dn:
         # prepare files
         write_random_lta_cube(dn, 'esp.cube')

--- a/horton/test/test_examples.py
+++ b/horton/test/test_examples.py
@@ -69,12 +69,14 @@ def test_example_expectation_r():
     check_script('./expectation_r.py', context.get_fn('examples/grid'))
 
 
+@attr('slow')
 def test_example_ap1rog_hubbard():
     required = [context.get_fn('examples/ap1rog/hubbard.py')]
     expected = ['checkpoint.h5']
     check_script_in_tmp('./hubbard.py', required, expected)
 
 
+@attr('slow')
 def test_example_ap1rog_extham_n2():
     required = [context.get_fn('examples/ap1rog/external_hamiltonian_n2_dense.py'),
                 context.get_fn('examples/hf_dft/rhf_n2_dense.py')]
@@ -84,6 +86,7 @@ def test_example_ap1rog_extham_n2():
     check_script_in_tmp('./rhf_n2_dense.py; ./external_hamiltonian_n2_dense.py', required, expected)
 
 
+@attr('slow')
 def test_example_ap1rog_extham_h2():
     required = [context.get_fn('examples/ap1rog/external_hamiltonian_h2_cholesky.py'),
                 context.get_fn('examples/hf_dft/rhf_h2_cholesky.py')]
@@ -92,6 +95,7 @@ def test_example_ap1rog_extham_h2():
     check_script_in_tmp('./rhf_h2_cholesky.py; ./external_hamiltonian_h2_cholesky.py', required, expected)
 
 
+@attr('slow')
 def test_example_ap1rog_extham_water():
     required = [context.get_fn('examples/ap1rog/external_hamiltonian_water_dense.py'),
                 context.get_fn('examples/hf_dft/rhf_water_dense.py')]
@@ -100,42 +104,50 @@ def test_example_ap1rog_extham_water():
     check_script_in_tmp('./rhf_water_dense.py; ./external_hamiltonian_water_dense.py', required, expected)
 
 
+@attr('slow')
 def test_example_ap1rog_h2_cholesky_321g():
     required = [context.get_fn('examples/ap1rog/h2_cholesky_3-21g.py')]
     expected = ['checkpoint.h5']
     check_script_in_tmp('./h2_cholesky_3-21g.py', required, expected)
 
 
+@attr('slow')
 def test_example_ap1rog_h2_cholesky_aug_cc_pvdz():
     required = [context.get_fn('examples/ap1rog/h2_cholesky_aug-cc-pvdz.py')]
     expected = ['checkpoint.h5']
     check_script_in_tmp('./h2_cholesky_aug-cc-pvdz.py', required, expected)
 
 
+@attr('slow')
 def test_example_ap1rog_h2_cholesky_cc_pvdz():
     required = [context.get_fn('examples/ap1rog/h2_cholesky_cc-pvdz.py')]
     expected = ['checkpoint.h5']
     check_script_in_tmp('./h2_cholesky_cc-pvdz.py', required, expected)
 
 
+@attr('slow')
 def test_example_ap1rog_h2_dense_321g():
     required = [context.get_fn('examples/ap1rog/h2_dense_3-21g.py')]
     expected = ['checkpoint.h5']
     check_script_in_tmp('./h2_dense_3-21g.py', required, expected)
 
 
+@attr('slow')
 def test_example_ap1rog_h2_dense_aug_cc_pvdz():
     required = [context.get_fn('examples/ap1rog/h2_dense_aug-cc-pvdz.py')]
     expected = ['checkpoint.h5']
     check_script_in_tmp('./h2_dense_aug-cc-pvdz.py', required, expected)
 
 
+@attr('slow')
 def test_example_ap1rog_water_cholesky_321g():
     required = [context.get_fn('examples/ap1rog/water_cholesky_3-21g.py')]
     expected = ['checkpoint.h5']
     check_script_in_tmp('./water_cholesky_3-21g.py', required, expected)
 
 
+@attr('slow')
+@attr('slow')
 def test_example_ap1rog_water_cholesky_321g_restart():
     required = [context.get_fn('examples/ap1rog/water_cholesky_3-21g.py'),
                 context.get_fn('examples/ap1rog/restart_water_cholesky_3-21g.py')]
@@ -143,42 +155,49 @@ def test_example_ap1rog_water_cholesky_321g_restart():
     check_script_in_tmp('./water_cholesky_3-21g.py; ./restart_water_cholesky_3-21g.py', required, expected)
 
 
+@attr('slow')
 def test_example_ap1rog_water_cholesky_sto3g():
     required = [context.get_fn('examples/ap1rog/water_cholesky_sto-3g.py')]
     expected = ['checkpoint.h5']
     check_script_in_tmp('./water_cholesky_sto-3g.py', required, expected)
 
 
+@attr('slow')
 def test_example_ap1rog_water_cholesky_cc_pvdz():
     required = [context.get_fn('examples/ap1rog/water_cholesky_cc-pvdz.py')]
     expected = ['checkpoint.h5']
     check_script_in_tmp('./water_cholesky_cc-pvdz.py', required, expected)
 
 
+@attr('slow')
 def test_example_ap1rog_water_dense_321g():
     required = [context.get_fn('examples/ap1rog/water_dense_3-21g.py')]
     expected = ['checkpoint.h5']
     check_script_in_tmp('./water_dense_3-21g.py', required, expected)
 
 
+@attr('slow')
 def test_example_ap1rog_water_dense_sto3g():
     required = [context.get_fn('examples/ap1rog/water_dense_sto-3g.py')]
     expected = ['checkpoint.h5']
     check_script_in_tmp('./water_dense_sto-3g.py', required, expected)
 
 
+@attr('slow')
 def test_example_ap1rog_water_dense_cc_pvdz():
     required = [context.get_fn('examples/ap1rog/water_dense_cc-pvdz.py')]
     expected = ['checkpoint.h5']
     check_script_in_tmp('./water_dense_cc-pvdz.py', required, expected)
 
 
+@attr('slow')
 def test_example_ap1rog_water_default():
     required = [context.get_fn('examples/ap1rog/water_default.py')]
     expected = ['checkpoint.h5']
     check_script_in_tmp('./water_default.py', required, expected)
 
 
+@attr('slow')
 def test_example_ap1rog_water_minimal():
     required = [context.get_fn('examples/ap1rog/water_minimal.py')]
     expected = ['checkpoint.h5']
@@ -209,82 +228,96 @@ def test_example_pt_mp2_water_cc_pvdz():
     check_script('./mp2_water_cc-pvdz.py', context.get_fn('examples/perturbation_theory'))
 
 
+@attr('slow')
 def test_example_pt_mp2_water_def2_svpd():
     check_script('./mp2_water_def2-svpd.py', context.get_fn('examples/perturbation_theory'))
 
 
+@attr('slow')
 def test_example_pta_h2_431g():
     required = [context.get_fn('examples/perturbation_theory/pta_h2_4-31g.py')]
     expected = ['checkpoint.h5']
     check_script_in_tmp('./pta_h2_4-31g.py', required, expected)
 
 
+@attr('slow')
 def test_example_pta_h2_cc_pvdz():
     required = [context.get_fn('examples/perturbation_theory/pta_h2_cc-pvdz.py')]
     expected = ['checkpoint.h5']
     check_script_in_tmp('./pta_h2_cc-pvdz.py', required, expected)
 
 
+@attr('slow')
 def test_example_pta_h2_def2_svpd():
     required = [context.get_fn('examples/perturbation_theory/pta_h2_def2-svpd.py')]
     expected = ['checkpoint.h5']
     check_script_in_tmp('./pta_h2_def2-svpd.py', required, expected)
 
 
+@attr('slow')
 def test_example_pta_water_431g():
     required = [context.get_fn('examples/perturbation_theory/pta_water_4-31g.py')]
     expected = ['checkpoint.h5']
     check_script_in_tmp('./pta_water_4-31g.py', required, expected)
 
 
+@attr('slow')
 def test_example_pta_water_cc_pvdz():
     required = [context.get_fn('examples/perturbation_theory/pta_water_cc-pvdz.py')]
     expected = ['checkpoint.h5']
     check_script_in_tmp('./pta_water_cc-pvdz.py', required, expected)
 
 
+@attr('slow')
 def test_example_pta_water_def2_svpd():
     required = [context.get_fn('examples/perturbation_theory/pta_water_def2-svpd.py')]
     expected = ['checkpoint.h5']
     check_script_in_tmp('./pta_water_def2-svpd.py', required, expected)
 
 
+@attr('slow')
 def test_example_ptb_h2_431g():
     required = [context.get_fn('examples/perturbation_theory/ptb_h2_4-31g.py')]
     expected = ['checkpoint.h5']
     check_script_in_tmp('./ptb_h2_4-31g.py', required, expected)
 
 
+@attr('slow')
 def test_example_ptb_h2_cc_pvdz():
     required = [context.get_fn('examples/perturbation_theory/ptb_h2_cc-pvdz.py')]
     expected = ['checkpoint.h5']
     check_script_in_tmp('./ptb_h2_cc-pvdz.py', required, expected)
 
 
+@attr('slow')
 def test_example_ptb_h2_def2_svpd():
     required = [context.get_fn('examples/perturbation_theory/ptb_h2_def2-svpd.py')]
     expected = ['checkpoint.h5']
     check_script_in_tmp('./ptb_h2_def2-svpd.py', required, expected)
 
 
+@attr('slow')
 def test_example_ptb_water_431g():
     required = [context.get_fn('examples/perturbation_theory/ptb_water_4-31g.py')]
     expected = ['checkpoint.h5']
     check_script_in_tmp('./ptb_water_4-31g.py', required, expected)
 
 
+@attr('slow')
 def test_example_ptb_water_cc_pvdz():
     required = [context.get_fn('examples/perturbation_theory/ptb_water_cc-pvdz.py')]
     expected = ['checkpoint.h5']
     check_script_in_tmp('./ptb_water_cc-pvdz.py', required, expected)
 
 
+@attr('slow')
 def test_example_ptb_water_def2_svpd():
     required = [context.get_fn('examples/perturbation_theory/ptb_water_def2-svpd.py')]
     expected = ['checkpoint.h5']
     check_script_in_tmp('./ptb_water_def2-svpd.py', required, expected)
 
 
+@attr('slow')
 def test_example_oe_water():
     required = [context.get_fn('examples/orbital_entanglement/water.py')]
     expected = ['i12.dat', 'checkpoint.h5', 's1.dat', 'orbital_entanglement.png']
@@ -299,6 +332,7 @@ def test_example_rhf_water_cholesky():
     check_script_in_tmp('./rhf_water_cholesky.py', required, expected)
 
 
+@attr('slow')
 def test_example_rhf_n2_dense():
     required = [context.get_fn('examples/hf_dft/rhf_n2_dense.py')]
     expected = ['n2-scf.molden', 'n2-scf.h5', 'n2-cas8-8.FCIDUMP',
@@ -319,30 +353,35 @@ def test_example_rhf_water_dense():
     check_script_in_tmp('./rhf_water_dense.py', required, expected)
 
 
+@attr('slow')
 def test_example_rks_water_gga():
     required = [context.get_fn('examples/hf_dft/rks_water_gga.py')]
     expected = ['water.h5']
     check_script_in_tmp('./rks_water_gga.py', required, expected)
 
 
+@attr('slow')
 def test_example_rks_water_hybgga():
     required = [context.get_fn('examples/hf_dft/rks_water_hybgga.py')]
     expected = ['water.h5']
     check_script_in_tmp('./rks_water_hybgga.py', required, expected)
 
 
+@attr('slow')
 def test_example_rks_water_lda():
     required = [context.get_fn('examples/hf_dft/rks_water_lda.py')]
     expected = ['water.h5']
     check_script_in_tmp('./rks_water_lda.py', required, expected)
 
 
+@attr('slow')
 def test_example_rks_water_numlda():
     required = [context.get_fn('examples/hf_dft/rks_water_numlda.py')]
     expected = ['water.h5']
     check_script_in_tmp('./rks_water_numlda.py', required, expected)
 
 
+@attr('slow')
 def test_example_rks_water_numgga():
     required = [context.get_fn('examples/hf_dft/rks_water_numgga.py')]
     expected = ['water.h5']
@@ -361,30 +400,35 @@ def test_example_uhf_methyl_dense():
     check_script_in_tmp('./uhf_methyl_dense.py', required, expected)
 
 
+@attr('slow')
 def test_example_uks_methyl_gga():
     required = [context.get_fn('examples/hf_dft/uks_methyl_gga.py')]
     expected = ['methyl.h5']
     check_script_in_tmp('./uks_methyl_gga.py', required, expected)
 
 
+@attr('slow')
 def test_example_uks_methyl_hybgga():
     required = [context.get_fn('examples/hf_dft/uks_methyl_hybgga.py')]
     expected = ['methyl.h5']
     check_script_in_tmp('./uks_methyl_hybgga.py', required, expected)
 
 
+@attr('slow')
 def test_example_uks_methyl_lda():
     required = [context.get_fn('examples/hf_dft/uks_methyl_lda.py')]
     expected = ['methyl.h5']
     check_script_in_tmp('./uks_methyl_lda.py', required, expected)
 
 
+@attr('slow')
 def test_example_uks_methyl_numlda():
     required = [context.get_fn('examples/hf_dft/uks_methyl_numlda.py')]
     expected = ['methyl.h5']
     check_script_in_tmp('./uks_methyl_numlda.py', required, expected)
 
 
+@attr('slow')
 def test_example_uks_methyl_numgga():
     required = [context.get_fn('examples/hf_dft/uks_methyl_numgga.py')]
     expected = ['methyl.h5']


### PR DESCRIPTION
Use "nosetests -a '!slow' -v horton" to run tests that are not slow
Use "nosetests -a 'slow' -v horton" to run tests that are slow
Use "nosetests -v horton" to run tests all tests

Tagged nosetests with time greater than 1s. If the tagged tests are skipped, all tests finish in about 80s using one core of Intel i5-4200U with SSD.
