### PR TITLE
Add slow tag to nosetests that take longer than 5s

### DIFF
--- a/horton/correlatedwfn/test/test_1dm_ap1rog.py
+++ b/horton/correlatedwfn/test/test_1dm_ap1rog.py
@@ -26,6 +26,7 @@ import numpy as np
 from horton.test.common import check_delta
 
 
+@attr('slow')
 def test_ap1rog_one_dm():
     fn_xyz = context.get_fn('test/li2.xyz')
     mol = IOData.from_file(fn_xyz)

--- a/horton/correlatedwfn/test/test_geminals.py
+++ b/horton/correlatedwfn/test/test_geminals.py
@@ -81,6 +81,7 @@ def test_ap1rog_cs_scf():
     assert (abs(energy - -1.151686291339) < 1e-6)
 
 
+@attr('slow')
 def test_ap1rog_cs_scf_restart():
     lf, occ_model, one, er, external, exp_alpha, olp = prepare_hf('6-31G')
 
@@ -88,6 +89,7 @@ def test_ap1rog_cs_scf_restart():
     geminal_solver = RAp1rog(lf, occ_model)
     guess = np.array([-0.1, -0.05, -0.02])
 
+@attr('slow')
     with tmpdir('horton.correlatedwfn.test.test_geminals.test_ap1rog_cs_scf_restart') as dn:
         checkpoint_fn = '%s/checkpoint.h5' % dn
         energy, g, l = geminal_solver(one, er, external['nn'], exp_alpha, olp,

--- a/horton/part/test/test_cpart.py
+++ b/horton/part/test/test_cpart.py
@@ -121,10 +121,12 @@ def test_hirshfeld_fake_pseudo_nowcor_global():
 
 
 
+@attr('slow')
 def test_hirshfeld_i_fake_local():
     check_fake('hi', pseudo=False, dowcor=True, local=True, absmean=0.428, threshold=1e-5)
 
 
+@attr('slow')
 def test_hirshfeld_i_fake_global():
     check_fake('hi', pseudo=False, dowcor=True, local=False, absmean=0.428, threshold=1e-5)
 
@@ -145,10 +147,13 @@ def test_hirshfeld_i_fake_pseudo_nowcor_global():
     check_fake('hi', pseudo=True, dowcor=True, local=False, absmean=0.400, threshold=1e-4)
 
 
+@attr('slow')
+@attr('slow')
 def test_hirshfeld_i_fake_local_greedy():
     check_fake('hi', pseudo=False, dowcor=True, local=True, absmean=0.428, threshold=1e-5, greedy=True)
 
 
+@attr('slow')
 def test_hirshfeld_i_fake_global_greedy():
     check_fake('hi', pseudo=False, dowcor=True, local=False, absmean=0.428, threshold=1e-5, greedy=True)
 
@@ -171,10 +176,12 @@ def test_hirshfeld_i_fake_pseudo_nowcor_global_greedy():
 
 
 
+@attr('slow')
 def test_hirshfeld_e_fake_local():
     check_fake('he', pseudo=False, dowcor=True, local=True, absmean=0.323, threshold=1e-4)
 
 
+@attr('slow')
 def test_hirshfeld_e_fake_global():
     check_fake('he', pseudo=False, dowcor=True, local=False, absmean=0.373, threshold=1e-4)
 
@@ -195,10 +202,13 @@ def test_hirshfeld_e_fake_pseudo_nowcor_global():
     check_fake('he', pseudo=True, dowcor=True, local=False, absmean=0.396, threshold=1e-4)
 
 
+@attr('slow')
+@attr('slow')
 def test_hirshfeld_e_fake_local_greedy():
     check_fake('he', pseudo=False, dowcor=True, local=True, absmean=0.323, threshold=1e-4, greedy=True)
 
 
+@attr('slow')
 def test_hirshfeld_e_fake_global_greedy():
     check_fake('he', pseudo=False, dowcor=True, local=False, absmean=0.374, threshold=1e-4, greedy=True)
 

--- a/horton/part/test/test_wpart.py
+++ b/horton/part/test/test_wpart.py
@@ -182,26 +182,31 @@ def test_hirshfeld_i_msa_hf_lan_global_greedy():
     check_msa_hf_lan('hi', expecting, local=False, greedy=True)
 
 
+@attr('slow')
 def test_hirshfeld_e_msa_hf_lan_local():
     expecting = np.array([1.06135407, -0.51795437, -0.50626239, -0.50136175, -0.48867641, 0.22835963, 0.240736, 0.23528162, 0.24816043])
     check_msa_hf_lan('he', expecting, local=True)
 
 
+@attr('slow')
 def test_hirshfeld_e_msa_hf_lan_global():
     expecting = np.array([1.06135407, -0.51795437, -0.50626239, -0.50136175, -0.48867641, 0.22835963, 0.240736, 0.23528162, 0.24816043])
     check_msa_hf_lan('he', expecting, local=False)
 
 
+@attr('slow')
 def test_hirshfeld_e_msa_hf_lan_local_greedy():
     expecting = np.array([1.06135407, -0.51795437, -0.50626239, -0.50136175, -0.48867641, 0.22835963, 0.240736, 0.23528162, 0.24816043])
     check_msa_hf_lan('he', expecting, local=True, greedy=True)
 
 
+@attr('slow')
 def test_hirshfeld_e_msa_hf_lan_global_greedy():
     expecting = np.array([1.06135407, -0.51795437, -0.50626239, -0.50136175, -0.48867641, 0.22835963, 0.240736, 0.23528162, 0.24816043])
     check_msa_hf_lan('he', expecting, local=False, greedy=True)
 
 
+@attr('slow')
 def test_is_msa_hf_lan():
     expecting = np.array([1.1721364, -0.5799622, -0.5654549, -0.5599638, -0.5444145, 0.2606699, 0.2721848, 0.2664377, 0.2783666]) # from HiPart
     check_msa_hf_lan('is', expecting, needs_padb=False)

--- a/horton/test/test_examples.py
+++ b/horton/test/test_examples.py
@@ -69,12 +69,14 @@ def test_example_expectation_r():
     check_script('./expectation_r.py', context.get_fn('examples/grid'))
 
 
+@attr('slow')
 def test_example_ap1rog_hubbard():
     required = [context.get_fn('examples/ap1rog/hubbard.py')]
     expected = ['checkpoint.h5']
     check_script_in_tmp('./hubbard.py', required, expected)
 
 
+@attr('slow')
 def test_example_ap1rog_extham_n2():
     required = [context.get_fn('examples/ap1rog/external_hamiltonian_n2_dense.py'),
                 context.get_fn('examples/hf_dft/rhf_n2_dense.py')]
@@ -92,6 +94,7 @@ def test_example_ap1rog_extham_h2():
     check_script_in_tmp('./rhf_h2_cholesky.py; ./external_hamiltonian_h2_cholesky.py', required, expected)
 
 
+@attr('slow')
 def test_example_ap1rog_extham_water():
     required = [context.get_fn('examples/ap1rog/external_hamiltonian_water_dense.py'),
                 context.get_fn('examples/hf_dft/rhf_water_dense.py')]
@@ -106,6 +109,7 @@ def test_example_ap1rog_h2_cholesky_321g():
     check_script_in_tmp('./h2_cholesky_3-21g.py', required, expected)
 
 
+@attr('slow')
 def test_example_ap1rog_h2_cholesky_aug_cc_pvdz():
     required = [context.get_fn('examples/ap1rog/h2_cholesky_aug-cc-pvdz.py')]
     expected = ['checkpoint.h5']
@@ -130,12 +134,15 @@ def test_example_ap1rog_h2_dense_aug_cc_pvdz():
     check_script_in_tmp('./h2_dense_aug-cc-pvdz.py', required, expected)
 
 
+@attr('slow')
 def test_example_ap1rog_water_cholesky_321g():
     required = [context.get_fn('examples/ap1rog/water_cholesky_3-21g.py')]
     expected = ['checkpoint.h5']
     check_script_in_tmp('./water_cholesky_3-21g.py', required, expected)
 
 
+@attr('slow')
+@attr('slow')
 def test_example_ap1rog_water_cholesky_321g_restart():
     required = [context.get_fn('examples/ap1rog/water_cholesky_3-21g.py'),
                 context.get_fn('examples/ap1rog/restart_water_cholesky_3-21g.py')]
@@ -149,12 +156,14 @@ def test_example_ap1rog_water_cholesky_sto3g():
     check_script_in_tmp('./water_cholesky_sto-3g.py', required, expected)
 
 
+@attr('slow')
 def test_example_ap1rog_water_cholesky_cc_pvdz():
     required = [context.get_fn('examples/ap1rog/water_cholesky_cc-pvdz.py')]
     expected = ['checkpoint.h5']
     check_script_in_tmp('./water_cholesky_cc-pvdz.py', required, expected)
 
 
+@attr('slow')
 def test_example_ap1rog_water_dense_321g():
     required = [context.get_fn('examples/ap1rog/water_dense_3-21g.py')]
     expected = ['checkpoint.h5']
@@ -167,18 +176,21 @@ def test_example_ap1rog_water_dense_sto3g():
     check_script_in_tmp('./water_dense_sto-3g.py', required, expected)
 
 
+@attr('slow')
 def test_example_ap1rog_water_dense_cc_pvdz():
     required = [context.get_fn('examples/ap1rog/water_dense_cc-pvdz.py')]
     expected = ['checkpoint.h5']
     check_script_in_tmp('./water_dense_cc-pvdz.py', required, expected)
 
 
+@attr('slow')
 def test_example_ap1rog_water_default():
     required = [context.get_fn('examples/ap1rog/water_default.py')]
     expected = ['checkpoint.h5']
     check_script_in_tmp('./water_default.py', required, expected)
 
 
+@attr('slow')
 def test_example_ap1rog_water_minimal():
     required = [context.get_fn('examples/ap1rog/water_minimal.py')]
     expected = ['checkpoint.h5']
@@ -231,18 +243,21 @@ def test_example_pta_h2_def2_svpd():
     check_script_in_tmp('./pta_h2_def2-svpd.py', required, expected)
 
 
+@attr('slow')
 def test_example_pta_water_431g():
     required = [context.get_fn('examples/perturbation_theory/pta_water_4-31g.py')]
     expected = ['checkpoint.h5']
     check_script_in_tmp('./pta_water_4-31g.py', required, expected)
 
 
+@attr('slow')
 def test_example_pta_water_cc_pvdz():
     required = [context.get_fn('examples/perturbation_theory/pta_water_cc-pvdz.py')]
     expected = ['checkpoint.h5']
     check_script_in_tmp('./pta_water_cc-pvdz.py', required, expected)
 
 
+@attr('slow')
 def test_example_pta_water_def2_svpd():
     required = [context.get_fn('examples/perturbation_theory/pta_water_def2-svpd.py')]
     expected = ['checkpoint.h5']
@@ -267,24 +282,28 @@ def test_example_ptb_h2_def2_svpd():
     check_script_in_tmp('./ptb_h2_def2-svpd.py', required, expected)
 
 
+@attr('slow')
 def test_example_ptb_water_431g():
     required = [context.get_fn('examples/perturbation_theory/ptb_water_4-31g.py')]
     expected = ['checkpoint.h5']
     check_script_in_tmp('./ptb_water_4-31g.py', required, expected)
 
 
+@attr('slow')
 def test_example_ptb_water_cc_pvdz():
     required = [context.get_fn('examples/perturbation_theory/ptb_water_cc-pvdz.py')]
     expected = ['checkpoint.h5']
     check_script_in_tmp('./ptb_water_cc-pvdz.py', required, expected)
 
 
+@attr('slow')
 def test_example_ptb_water_def2_svpd():
     required = [context.get_fn('examples/perturbation_theory/ptb_water_def2-svpd.py')]
     expected = ['checkpoint.h5']
     check_script_in_tmp('./ptb_water_def2-svpd.py', required, expected)
 
 
+@attr('slow')
 def test_example_oe_water():
     required = [context.get_fn('examples/orbital_entanglement/water.py')]
     expected = ['i12.dat', 'checkpoint.h5', 's1.dat', 'orbital_entanglement.png']
@@ -337,12 +356,14 @@ def test_example_rks_water_lda():
     check_script_in_tmp('./rks_water_lda.py', required, expected)
 
 
+@attr('slow')
 def test_example_rks_water_numlda():
     required = [context.get_fn('examples/hf_dft/rks_water_numlda.py')]
     expected = ['water.h5']
     check_script_in_tmp('./rks_water_numlda.py', required, expected)
 
 
+@attr('slow')
 def test_example_rks_water_numgga():
     required = [context.get_fn('examples/hf_dft/rks_water_numgga.py')]
     expected = ['water.h5']
@@ -379,12 +400,14 @@ def test_example_uks_methyl_lda():
     check_script_in_tmp('./uks_methyl_lda.py', required, expected)
 
 
+@attr('slow')
 def test_example_uks_methyl_numlda():
     required = [context.get_fn('examples/hf_dft/uks_methyl_numlda.py')]
     expected = ['methyl.h5']
     check_script_in_tmp('./uks_methyl_numlda.py', required, expected)
 
 
+@attr('slow')
 def test_example_uks_methyl_numgga():
     required = [context.get_fn('examples/hf_dft/uks_methyl_numgga.py')]
     expected = ['methyl.h5']


### PR DESCRIPTION
Use "nosetests -a '!slow' -v horton" to run tests that are not slow
Use "nosetests -a 'slow' -v horton" to run tests that are slow
Use "nosetests -v horton" to run tests all tests

Tagged nosetests with time greater than 5s. If the tagged tests are skipped, all tests finish in about 230s using one core of Intel i5-4200U with SSD.
